### PR TITLE
Avoid creating entity instances without constructor args

### DIFF
--- a/src/Trappar/AliceGenerator/ValueVisitor.php
+++ b/src/Trappar/AliceGenerator/ValueVisitor.php
@@ -188,7 +188,8 @@ class ValueVisitor
         $this->persister->preProcess($object);
 
         // Create a new instance of this class to check values against
-        $newObject = new $class();
+        $reflectionClass = new \ReflectionClass($class);
+        $newObject = $reflectionClass->newInstanceWithoutConstructor();
 
         $classMetadata = $this->metadataFactory->getMetadataForClass($class);
         $properties    = $classMetadata->propertyMetadata;


### PR DESCRIPTION
We can't create a new instance of an entity without knowing if it has mandatory constructor args, otherwise the `generate:fixtures` gives this kind of error:

> Warning: Missing argument 1 for AppBundle\Entity\User::__construct(), called in /srv/app/symfony/vendor/trappar/alice-generator/src/Trappar/AliceGenerator/ValueVisitor.php on line 191 and defined
