### PR TITLE
Change ReferenceNamers getPrefix into getReference. fixes #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.3.0
+* BC Break: changed ReferenceNamer interface `getPrefix` into `getReference` to allow non-numeric keys in namers 
+
 ## Version 0.2.0
 * Enable strict type checking in all cases in ValueVisitor. Add option to disable it. (reported by nedlukies)
 

--- a/src/Trappar/AliceGenerator/ReferenceNamer/ClassNamer.php
+++ b/src/Trappar/AliceGenerator/ReferenceNamer/ClassNamer.php
@@ -6,6 +6,11 @@ use Doctrine\Common\Util\ClassUtils;
 
 class ClassNamer implements ReferenceNamerInterface
 {
+    public function createReference($object, $key)
+    {
+        return $this->createPrefix($object).$key;
+    }
+
     public function createPrefix($object)
     {
         $class = ClassUtils::getClass($object);

--- a/src/Trappar/AliceGenerator/ReferenceNamer/NamespaceNamer.php
+++ b/src/Trappar/AliceGenerator/ReferenceNamer/NamespaceNamer.php
@@ -9,6 +9,11 @@ class NamespaceNamer implements ReferenceNamerInterface
     protected $namespaceSeparator = '';
     protected $ignoredNamespaces = [];
 
+    public function createReference($object, $key)
+    {
+        return $this->createPrefix($object).$key;
+    }
+
     public function createPrefix($object)
     {
         $class = ClassUtils::getClass($object);

--- a/src/Trappar/AliceGenerator/ReferenceNamer/PropertyReferenceNamer.php
+++ b/src/Trappar/AliceGenerator/ReferenceNamer/PropertyReferenceNamer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Trappar\AliceGenerator\ReferenceNamer;
+
+use Doctrine\Common\Util\ClassUtils;
+
+/**
+ * Names by the value of a property from the generated object
+ *
+ * if class of object is not mapped to a property, the behaviour is similar to ClassNamer
+ */
+class PropertyReferenceNamer implements ReferenceNamerInterface
+{
+    /**
+     * PropertyNames mappings
+     *
+     * maps the className of an generated object to its unique property-value to be used
+     * @var Array
+     */
+    protected $propertyNames;
+
+    /**
+     * PropertyReferenceNamer constructor.
+     * @param array $class => $propertyName
+     */
+    public function __construct(Array $propertyNames)
+    {
+        $this->propertyNames = $propertyNames;
+    }
+
+    public function createReference($object, $key)
+    {
+        $class = ClassUtils::getClass($object);
+
+        $parts     = explode('\\', $class);
+        $className = $parts[count($parts) - 1];
+
+        if (array_key_exists($class,$this->propertyNames)) {
+            $propertyName = $this->propertyNames[$class];
+            return $className.'-'.$object->$propertyName;
+        } else {
+            return $className.'-'.$key;
+        }
+    }
+}

--- a/src/Trappar/AliceGenerator/ReferenceNamer/ReferenceNamerInterface.php
+++ b/src/Trappar/AliceGenerator/ReferenceNamer/ReferenceNamerInterface.php
@@ -5,8 +5,9 @@ namespace Trappar\AliceGenerator\ReferenceNamer;
 interface ReferenceNamerInterface
 {
     /**
-     * @param $object
+     * @param object $object the generated object
+     * @param int $key a unique index for all generated objects of the class of $object
      * @return string
      */
-    public function createPrefix($object);
+    public function createReference($object, $key);
 }

--- a/src/Trappar/AliceGenerator/ValueVisitor.php
+++ b/src/Trappar/AliceGenerator/ValueVisitor.php
@@ -131,14 +131,14 @@ class ValueVisitor
                 return;
             }
 
-            $result          = $this->persistedObjectCache->find($object);
-            $referencePrefix = $this->fixtureGenerationContext->getReferenceNamer()->createPrefix($object);
+            $result         = $this->persistedObjectCache->find($object);
+            $referenceNamer = $this->fixtureGenerationContext->getReferenceNamer();
 
             switch ($result) {
                 case PersistedObjectCache::OBJECT_NOT_FOUND:
                     if ($this->recursionDepth <= $this->fixtureGenerationContext->getMaximumRecursion()) {
                         $key       = $this->persistedObjectCache->add($object);
-                        $reference = $referencePrefix . $key;
+                        $reference = $referenceNamer->createReference($object, $key);
 
                         $objectAdded = $this->handlePersistedObject($object, $reference);
 
@@ -159,7 +159,7 @@ class ValueVisitor
 
                     return;
                 default:
-                    $valueContext->setValue('@' . $referencePrefix . $result);
+                    $valueContext->setValue('@' . $referenceNamer->createReference($object, $result));
 
                     return;
             }

--- a/tests/Trappar/AliceGenerator/FixtureGeneratorTest.php
+++ b/tests/Trappar/AliceGenerator/FixtureGeneratorTest.php
@@ -9,6 +9,7 @@ use Trappar\AliceGenerator\FixtureGenerationContext;
 use Trappar\AliceGenerator\FixtureGeneratorBuilder;
 use Trappar\AliceGenerator\Persister\NonSpecificPersister;
 use Trappar\AliceGenerator\ReferenceNamer\NamespaceNamer;
+use Trappar\AliceGenerator\ReferenceNamer\PropertyReferenceNamer;
 use Trappar\AliceGenerator\Tests\Fixtures\ObjectWithConstructor;
 use Trappar\AliceGenerator\Tests\Fixtures\Post;
 use Trappar\AliceGenerator\Tests\Fixtures\SortTester;
@@ -133,6 +134,18 @@ class FixtureGeneratorTest extends TestCase
         );
 
         $this->assertArrayHasKey('TrapparAliceGeneratorTestsFixturesUser-1', $results[User::class]);
+    }
+
+    public function testUniqueReferenceNamer()
+    {
+        $user = $this->createTestData();
+
+        $results = FixtureUtils::getFixturesFromObjects(
+            $user,
+            FixtureGenerationContext::create()->setReferenceNamer(new PropertyReferenceNamer([User::class => 'username']))
+        );
+
+        $this->assertArrayHasKey('User-testUser', $results[User::class]);
     }
 
     public function testIgnoringEmptyEntity()


### PR DESCRIPTION
to fix #9 I created a non backwards compatible change in the Interface, and added a small test.

The PropertyReferenceNamer isn't the best usecase for this, but this is how I would use it. We can move this to the testing namespace, if you feel like it.

best regards
Philipp